### PR TITLE
Fix CMakeLists version import and add build system requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ ${cmd}\"\"\"")
   string(STRIP "${_output}" _output)
   set(${outvar} "${_output}" PARENT_SCOPE)
 endfunction()
-_pycmd(PYFLANN_VERSION "import setup; print(setup.version)")
+_pycmd(PYFLANN_VERSION "import setup; print(setup.VERSION)")
 
 message(STATUS "PYFLANN_VERSION = ${PYFLANN_VERSION}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,6 @@ exclude = '''
     \.git
 )/
 '''
+
+[build-system]
+requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja"]


### PR DESCRIPTION
- Fix setup.py version import in CMakeLists

  When running `run_developer_setup.sh`:
  
  ```
  ...
  -- Detecting CXX compiler ABI info - done
  -- Detecting CXX compile features
  -- Detecting CXX compile features - done
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
  AttributeError: module 'setup' has no attribute 'version'
  ERRORFailed when running python code: """
  import setup; print(setup.version)"""
  CMake Error at CMakeLists.txt:24 (message):
    Python command failed with error code: 1
  Call Stack (most recent call first):
    CMakeLists.txt:30 (_pycmd)
  
  -- Configuring incomplete, errors occurred!
  ```
  
  It looks like `setup.py` has a variable called `VERSION` instead of `version`
  so change `setup.version` to `setup.VERSION`.

- Add build-system requirements to pyproject.toml

  When doing `run_developer_setup.sh` / `pip install -e .` in the
  [provision docker image](https://github.com/WildbookOrg/wildbook-ia/blob/master/devops/provision/Dockerfile):
  
  ```
  Obtaining file:///wbia/flann
    Installing build dependencies ... done
    Getting requirements to build wheel ... error
    ERROR: Command errored out with exit status 1:
     command: /virtualenv/env3/bin/python3 /virtualenv/env3/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmp4uiq8e13
         cwd: /wbia/flann
    Complete output (18 lines):
    Traceback (most recent call last):
      File "/virtualenv/env3/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 280, in <module>
        main()
      File "/virtualenv/env3/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 263, in main
        json_out['return_val'] = hook(**hook_input['kwargs'])
      File "/virtualenv/env3/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 114, in get_requires_for_build_wheel
        return hook(config_settings)
      File "/tmp/pip-build-env-syz53y2_/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 148, in get_requires_for_build_wheel
        config_settings, requirements=['wheel'])
      File "/tmp/pip-build-env-syz53y2_/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 128, in _get_build_requires
        self.run_setup()
      File "/tmp/pip-build-env-syz53y2_/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 250, in run_setup
        self).run_setup(setup_script=setup_script)
      File "/tmp/pip-build-env-syz53y2_/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 143, in run_setup
        exec(compile(code, __file__, 'exec'), locals())
      File "setup.py", line 252, in <module>
        import skbuild
    ModuleNotFoundError: No module named 'skbuild'
    ----------------------------------------
  ERROR: Command errored out with exit status 1: /virtualenv/env3/bin/python3 /virtualenv/env3/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmp4uiq8e13 Check the logs for full command output.
  ```
  
  According to the
  [scikit-build documentation](https://scikit-build.readthedocs.io/en/latest/usage.html#example-of-setup-py-cmakelists-txt-and-pyproject-toml),
  we should add a `[build-system]` with `scikit-build` etc in the build
  requirements.
